### PR TITLE
fix(ui): align shuffle button position with album screen layout

### DIFF
--- a/app/src/main/kotlin/com/convx/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/convx/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -1457,7 +1457,58 @@ fun LocalPlaylistHeader(
                 horizontalArrangement = Arrangement.spacedBy(24.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // More Options Button (Left - Circular)
+                // Shuffle Button (Left - Circular)
+                GlassCircleButton(
+                    onClick = {
+                        playerConnection.playQueue(
+                            ListQueue(
+                                title = playlist.playlist.name,
+                                items = songs.shuffled().map { it.song.toMediaItem() },
+                            )
+                        )
+                    },
+                    size = 48.dp,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.shuffle),
+                        contentDescription = stringResource(R.string.shuffle),
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+
+                // Play Button (Center - Large Circle)
+                // A playlist's own id never matches a song's albumId (different
+                // id spaces) — that comparison was always false, so this button
+                // never showed "pause" and always restarted the queue on tap.
+                // Membership of the current song in this playlist's own song
+                // list is the same "is this the active context" heuristic
+                // AlbumScreen uses (there, albumId happens to match directly).
+                val isPlayingThisPlaylist = isPlaying && songs.any { it.song.id == mediaMetadata?.id }
+                GlassCircleButton(
+                    onClick = {
+                        if (isPlayingThisPlaylist) {
+                            playerConnection.player.pause()
+                        } else if (songs.any { it.song.id == mediaMetadata?.id }) {
+                            playerConnection.player.play()
+                        } else {
+                            playerConnection.playQueue(
+                                ListQueue(
+                                    title = playlist.playlist.name,
+                                    items = songs.map { it.song.toMediaItem() },
+                                )
+                            )
+                        }
+                    },
+                    size = 72.dp,
+                ) {
+                    AnimatedPlayPauseIcon(
+                        isPlaying = isPlayingThisPlaylist,
+                        size = 32.dp,
+                        modifier = Modifier.offset(x = 2.dp),
+                    )
+                }
+
+                // More Options Button (Right - Circular)
                 GlassCircleButton(
                     onClick = {
                         menuState.show {
@@ -1527,58 +1578,7 @@ fun LocalPlaylistHeader(
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.more_vert),
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                    )
-                }
-
-                // Play Button (Center - Large Circle)
-                // A playlist's own id never matches a song's albumId (different
-                // id spaces) — that comparison was always false, so this button
-                // never showed "pause" and always restarted the queue on tap.
-                // Membership of the current song in this playlist's own song
-                // list is the same "is this the active context" heuristic
-                // AlbumScreen uses (there, albumId happens to match directly).
-                val isPlayingThisPlaylist = isPlaying && songs.any { it.song.id == mediaMetadata?.id }
-                GlassCircleButton(
-                    onClick = {
-                        if (isPlayingThisPlaylist) {
-                            playerConnection.player.pause()
-                        } else if (songs.any { it.song.id == mediaMetadata?.id }) {
-                            playerConnection.player.play()
-                        } else {
-                            playerConnection.playQueue(
-                                ListQueue(
-                                    title = playlist.playlist.name,
-                                    items = songs.map { it.song.toMediaItem() },
-                                )
-                            )
-                        }
-                    },
-                    size = 72.dp,
-                ) {
-                    AnimatedPlayPauseIcon(
-                        isPlaying = isPlayingThisPlaylist,
-                        size = 32.dp,
-                        modifier = Modifier.offset(x = 2.dp),
-                    )
-                }
-
-                // Shuffle Button (Right - Circular)
-                GlassCircleButton(
-                    onClick = {
-                        playerConnection.playQueue(
-                            ListQueue(
-                                title = playlist.playlist.name,
-                                items = songs.shuffled().map { it.song.toMediaItem() },
-                            )
-                        )
-                    },
-                    size = 48.dp,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.shuffle),
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.more_options),
                         modifier = Modifier.size(20.dp),
                     )
                 }


### PR DESCRIPTION
Swap the shuffle and more options buttons in LocalPlaylistScreen to mirror the AlbumScreen action row ([Shuffle] - [Play] - [More / Favorite]). This ensures consistent button placement and muscle memory across both album and playlist views.

## 🚀 What does this PR do?
- [ ] 🐛 Fixes a bug (Issue #___)
- [ ] ✨ Adds a new feature
- [x] 🎨 UI/Design update
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code refactoring

## 📸 Screenshots / Recordings
| Before | After |
| :---: | :---: |
| <img width="573" height="1280" alt="Telegram Saved Messages - 2026-09-03 10 44 50" src="https://github.com/user-attachments/assets/8fb7f304-66b5-43ff-bed9-4eb9d0a46643" /> | <img width="573" height="1280" alt="Telegram Saved Messages - 2026-09-03 10 44 48" src="https://github.com/user-attachments/assets/b9be82b7-0fe0-4f28-8d2f-da1c1787a566" /> |

## 🛠️ Checklist
- [x] My code follows the project's style guidelines.
- [x] I have tested my changes on an Android device/emulator.
- [x] I have verified that no new warnings/errors are introduced.
- [x] I have updated the documentation (if necessary).

## 📝 Additional Notes
