### PR TITLE
feat(modulehost): add declarative module host with app settings seam

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -328,6 +328,7 @@ dependencies {
     implementation(project(":jiosaavn"))
     implementation(project(":spotify"))
     implementation(project(":spine"))
+    implementation(project(":modulehost"))
 
 
     implementation(libs.ktor.client.core)

--- a/app/src/main/kotlin/com/convx/music/App.kt
+++ b/app/src/main/kotlin/com/convx/music/App.kt
@@ -33,6 +33,7 @@ import com.music.kugou.KuGou
 import com.music.lastfm.LastFM
 import com.convx.music.constants.*
 import com.convx.music.di.ApplicationScope
+import com.convx.music.modulehost.ConvxDeclarativeModuleHost
 import com.convx.music.extensions.toEnum
 import com.convx.music.extensions.toInetSocketAddress
 import com.convx.music.utils.CrashHandler
@@ -66,8 +67,14 @@ class App : Application(), SingletonImageLoader.Factory {
     @ApplicationScope
     lateinit var applicationScope: CoroutineScope
 
+    @Inject
+    lateinit var declarativeModuleHost: ConvxDeclarativeModuleHost
+
     override fun onCreate() {
         super.onCreate()
+        // The Application is the single lifecycle owner for the declarative host.
+        // Settings only observes its snapshot; it does not start a second host.
+        declarativeModuleHost.start()
 
         // Restored synchronously, before anything else can start: the async
         // DataStore collector further down (applicationScope.launch { ... }

--- a/app/src/main/kotlin/com/convx/music/App.kt
+++ b/app/src/main/kotlin/com/convx/music/App.kt
@@ -74,7 +74,9 @@ class App : Application(), SingletonImageLoader.Factory {
         super.onCreate()
         // The Application is the single lifecycle owner for the declarative host.
         // Settings only observes its snapshot; it does not start a second host.
-        declarativeModuleHost.start()
+        // The private files dir is the persistent store root: registry state and
+        // installed package bytes survive process restarts here.
+        declarativeModuleHost.start(filesDir)
 
         // Restored synchronously, before anything else can start: the async
         // DataStore collector further down (applicationScope.launch { ... }

--- a/app/src/main/kotlin/com/convx/music/modulehost/ConvxDeclarativeModuleHost.kt
+++ b/app/src/main/kotlin/com/convx/music/modulehost/ConvxDeclarativeModuleHost.kt
@@ -1,0 +1,26 @@
+package com.convx.music.modulehost
+
+import com.convx.music.BuildConfig
+import com.convx.modulehost.DeclarativeModuleHost
+import com.convx.modulehost.DeclarativeModuleHostLifecycle
+import com.convx.modulehost.DeclarativeModuleHostSnapshot
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ConvxDeclarativeModuleHost @Inject constructor() {
+    private val host = DeclarativeModuleHost(BuildConfig.VERSION_NAME)
+
+    @Synchronized
+    fun start() {
+        if (host.snapshot().lifecycle == DeclarativeModuleHostLifecycle.NOT_STARTED) {
+            host.start()
+        }
+    }
+
+    fun snapshot(): DeclarativeModuleHostSnapshot = host.snapshot()
+}
+
+object DeclarativeModuleHostRoutes {
+    const val SETTINGS = "settings/declarative-modules"
+}

--- a/app/src/main/kotlin/com/convx/music/modulehost/ConvxDeclarativeModuleHost.kt
+++ b/app/src/main/kotlin/com/convx/music/modulehost/ConvxDeclarativeModuleHost.kt
@@ -4,21 +4,62 @@ import com.convx.music.BuildConfig
 import com.convx.modulehost.DeclarativeModuleHost
 import com.convx.modulehost.DeclarativeModuleHostLifecycle
 import com.convx.modulehost.DeclarativeModuleHostSnapshot
+import com.convx.modulehost.ModuleStore
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * App-owned wrapper around the declarative module host.
+ *
+ * The Application calls [start] with its private files dir once at startup; the
+ * store is then opened (registry restored from disk) before the host starts.
+ * All mutations return a fresh snapshot so callers never render stale state.
+ */
 @Singleton
 class ConvxDeclarativeModuleHost @Inject constructor() {
-    private val host = DeclarativeModuleHost(BuildConfig.VERSION_NAME)
+    @Volatile
+    private var host: DeclarativeModuleHost = DeclarativeModuleHost(BuildConfig.VERSION_NAME)
 
     @Synchronized
-    fun start() {
+    fun start(storeRoot: File? = null) {
+        if (storeRoot != null && !storeOpen) {
+            host = DeclarativeModuleHost(BuildConfig.VERSION_NAME, ModuleStore(storeRoot.toPath()))
+            storeOpen = true
+        }
         if (host.snapshot().lifecycle == DeclarativeModuleHostLifecycle.NOT_STARTED) {
             host.start()
         }
     }
 
     fun snapshot(): DeclarativeModuleHostSnapshot = host.snapshot()
+
+    /** Install a not-yet-installed package; returns the fresh snapshot or throws. */
+    @Synchronized
+    fun install(packageBytes: ByteArray): DeclarativeModuleHostSnapshot {
+        host.installNew(packageBytes)
+        return host.snapshot()
+    }
+
+    @Synchronized
+    fun enable(moduleId: String): DeclarativeModuleHostSnapshot {
+        host.enable(moduleId)
+        return host.snapshot()
+    }
+
+    @Synchronized
+    fun disable(moduleId: String): DeclarativeModuleHostSnapshot {
+        host.disable(moduleId)
+        return host.snapshot()
+    }
+
+    @Synchronized
+    fun remove(moduleId: String): DeclarativeModuleHostSnapshot {
+        host.remove(moduleId)
+        return host.snapshot()
+    }
+
+    private var storeOpen = false
 }
 
 object DeclarativeModuleHostRoutes {

--- a/app/src/main/kotlin/com/convx/music/modulehost/DeclarativeModuleHostViewModel.kt
+++ b/app/src/main/kotlin/com/convx/music/modulehost/DeclarativeModuleHostViewModel.kt
@@ -1,13 +1,69 @@
 package com.convx.music.modulehost
 
+import android.content.ContentResolver
+import android.net.Uri
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.convx.modulehost.DeclarativeModuleHostSnapshot
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
 class DeclarativeModuleHostViewModel @Inject constructor(
-    moduleHost: ConvxDeclarativeModuleHost,
+    private val moduleHost: ConvxDeclarativeModuleHost,
 ) : ViewModel() {
-    val snapshot: DeclarativeModuleHostSnapshot = moduleHost.snapshot()
+    private val _snapshot = MutableStateFlow(moduleHost.snapshot())
+    val snapshot: StateFlow<DeclarativeModuleHostSnapshot> = _snapshot.asStateFlow()
+
+    /** User-facing failure surfaced by the screen (e.g. picker read, validation). */
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _busy = MutableStateFlow(false)
+    val busy: StateFlow<Boolean> = _busy.asStateFlow()
+
+    fun installPackage(resolver: ContentResolver, uri: Uri) {
+        mutate {
+            val bytes = withContext(Dispatchers.IO) {
+                resolver.openInputStream(uri)?.use { it.readBytes() }
+                    ?: error("cannot read the selected file")
+            }
+            moduleHost.install(bytes)
+        }
+    }
+
+    fun enable(moduleId: String) {
+        mutate { moduleHost.enable(moduleId) }
+    }
+
+    fun disable(moduleId: String) {
+        mutate { moduleHost.disable(moduleId) }
+    }
+
+    fun remove(moduleId: String) {
+        mutate { moduleHost.remove(moduleId) }
+    }
+
+    fun dismissError() {
+        _error.value = null
+    }
+
+    private fun mutate(operation: suspend () -> DeclarativeModuleHostSnapshot) {
+        viewModelScope.launch {
+            _busy.value = true
+            try {
+                _snapshot.value = operation()
+            } catch (error: Exception) {
+                _error.value = error.message ?: error.javaClass.simpleName
+            } finally {
+                _busy.value = false
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/com/convx/music/modulehost/DeclarativeModuleHostViewModel.kt
+++ b/app/src/main/kotlin/com/convx/music/modulehost/DeclarativeModuleHostViewModel.kt
@@ -1,0 +1,13 @@
+package com.convx.music.modulehost
+
+import androidx.lifecycle.ViewModel
+import com.convx.modulehost.DeclarativeModuleHostSnapshot
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class DeclarativeModuleHostViewModel @Inject constructor(
+    moduleHost: ConvxDeclarativeModuleHost,
+) : ViewModel() {
+    val snapshot: DeclarativeModuleHostSnapshot = moduleHost.snapshot()
+}

--- a/app/src/main/kotlin/com/convx/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/convx/music/ui/screens/NavigationBuilder.kt
@@ -88,6 +88,8 @@ import com.convx.music.ui.screens.recognition.RecognitionScreen
 import com.convx.music.ui.screens.recognition.RecognitionHistoryScreen
 import com.convx.music.ui.screens.settings.ModuleSourceScreen
 import com.convx.music.ui.screens.settings.ModuleDetailScreen
+import com.convx.music.ui.screens.settings.DeclarativeModuleHostSettingsScreen
+import com.convx.music.modulehost.DeclarativeModuleHostRoutes
 import com.convx.music.ui.screens.settings.UpdateSettings
 import com.convx.music.ui.screens.wrapped.WrappedScreen
 import com.convx.music.vivimusic.updater.UpdateScreen
@@ -466,6 +468,10 @@ fun NavGraphBuilder.navigationBuilder(
 
     sharedComposable("settings/modules") {
         ModuleSourceScreen(navController, scrollBehavior)
+    }
+
+    sharedComposable(DeclarativeModuleHostRoutes.SETTINGS) {
+        DeclarativeModuleHostSettingsScreen(navController, scrollBehavior)
     }
 
     sharedComposable(

--- a/app/src/main/kotlin/com/convx/music/ui/screens/settings/DeclarativeModuleHostSettingsScreen.kt
+++ b/app/src/main/kotlin/com/convx/music/ui/screens/settings/DeclarativeModuleHostSettingsScreen.kt
@@ -1,5 +1,7 @@
 package com.convx.music.ui.screens.settings
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -9,23 +11,31 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.convx.music.LocalPlayerAwareWindowInsets
 import com.convx.music.R
 import com.convx.music.modulehost.DeclarativeModuleHostViewModel
 import com.convx.modulehost.DeclarativeModuleHostLifecycle
+import com.convx.modulehost.ModuleState
 import com.convx.music.ui.component.IconButton
 import com.convx.music.ui.component.Material3SettingsGroup
 import com.convx.music.ui.component.Material3SettingsItem
@@ -39,7 +49,18 @@ fun DeclarativeModuleHostSettingsScreen(
     scrollBehavior: TopAppBarScrollBehavior,
     viewModel: DeclarativeModuleHostViewModel = hiltViewModel(),
 ) {
-    val snapshot = viewModel.snapshot
+    val context = LocalContext.current
+    val snapshot by viewModel.snapshot.collectAsStateWithLifecycle()
+    val errorMessage by viewModel.error.collectAsStateWithLifecycle()
+    val busy by viewModel.busy.collectAsStateWithLifecycle()
+    var pendingRemove by rememberSaveable { mutableStateOf<String?>(null) }
+
+    val installLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let { viewModel.installPackage(context.contentResolver, it) }
+    }
+
     val started = snapshot.lifecycle == DeclarativeModuleHostLifecycle.STARTED
 
     Column(
@@ -59,35 +80,116 @@ fun DeclarativeModuleHostSettingsScreen(
         )
         Material3SettingsGroup(
             title = stringResource(R.string.declarative_modules),
-            items = listOf(
-                Material3SettingsItem(
-                    icon = painterResource(R.drawable.link),
-                    title = {
-                        Text(
-                            stringResource(
-                                if (started) R.string.module_host_ready else R.string.module_host_not_started,
+            items = buildList {
+                add(
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.add),
+                        title = { Text(stringResource(R.string.module_host_install)) },
+                        description = { Text(stringResource(R.string.module_host_install_hint)) },
+                        enabled = started && !busy,
+                        onClick = { installLauncher.launch(arrayOf("application/octet-stream")) },
+                    )
+                )
+                add(
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.info),
+                        title = {
+                            Text(
+                                stringResource(
+                                    if (started) R.string.module_host_ready else R.string.module_host_not_started,
+                                )
                             )
-                        )
-                    },
-                    description = {
-                        Text(stringResource(R.string.module_host_version, snapshot.convxVersion))
-                    },
-                ),
-                Material3SettingsItem(
-                    icon = painterResource(R.drawable.info),
-                    title = {
-                        Text(stringResource(R.string.module_host_registered_modules, snapshot.modules.size))
-                    },
-                    description = {
-                        Text(stringResource(R.string.module_host_no_installation))
-                    },
-                ),
-                Material3SettingsItem(
-                    icon = painterResource(R.drawable.security),
-                    title = { Text(stringResource(R.string.module_host_scope)) },
-                    enabled = false,
-                ),
-            ),
+                        },
+                        description = { Text(stringResource(R.string.module_host_version, snapshot.convxVersion)) },
+                        enabled = false,
+                    )
+                )
+            },
+        )
+
+        if (snapshot.modules.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(27.dp))
+            Material3SettingsGroup(
+                title = stringResource(R.string.module_host_installed_modules),
+                items = snapshot.modules.map { module ->
+                    // Row tap toggles state only where the registry allows the
+                    // transition; removal is the trailing trash button alone, so
+                    // tapping it never also toggles the module.
+                    val rowAction: (() -> Unit)? = when (module.state) {
+                        ModuleState.INSTALLED, ModuleState.DISABLED -> {
+                            { viewModel.enable(module.manifest.id) }
+                        }
+                        ModuleState.ENABLED -> {
+                            { viewModel.disable(module.manifest.id) }
+                        }
+                        else -> null
+                    }
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.grid_view),
+                        title = { Text(module.manifest.name) },
+                        description = {
+                            Text(
+                                stringResource(
+                                    R.string.module_host_module_state,
+                                    module.manifest.version,
+                                    stringResource(module.state.stringRes()),
+                                )
+                            )
+                        },
+                        onClick = rowAction,
+                        trailingContent = {
+                            IconButton(
+                                onClick = { pendingRemove = module.manifest.id },
+                                onLongClick = { pendingRemove = module.manifest.id },
+                            ) {
+                                Icon(
+                                    painterResource(R.drawable.delete),
+                                    contentDescription = stringResource(R.string.module_host_remove),
+                                )
+                            }
+                        },
+                    )
+                },
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+
+    val removing = pendingRemove?.let { id -> snapshot.modules.firstOrNull { it.manifest.id == id } }
+    if (removing != null) {
+        AlertDialog(
+            onDismissRequest = { pendingRemove = null },
+            title = { Text(stringResource(R.string.module_host_remove_confirm_title)) },
+            text = { Text(stringResource(R.string.module_host_remove_confirm_body, removing.manifest.name)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.remove(removing.manifest.id)
+                    pendingRemove = null
+                }) {
+                    Text(stringResource(R.string.module_host_remove))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRemove = null }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            },
+        )
+    }
+
+    val message = errorMessage
+    if (message != null) {
+        AlertDialog(
+            onDismissRequest = viewModel::dismissError,
+            confirmButton = {
+                TextButton(onClick = viewModel::dismissError) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            },
+            icon = { Icon(painterResource(R.drawable.error), null) },
+            title = { Text(stringResource(R.string.module_host_error)) },
+            text = { Text(message) },
         )
     }
 
@@ -107,4 +209,17 @@ fun DeclarativeModuleHostSettingsScreen(
         windowInsets = appTopBarWindowInsets(),
         scrollBehavior = scrollBehavior,
     )
+}
+
+private fun ModuleState.stringRes(): Int = when (this) {
+    ModuleState.DISCOVERED -> R.string.module_state_discovered
+    ModuleState.VALIDATED -> R.string.module_state_validated
+    ModuleState.STAGED -> R.string.module_state_staged
+    ModuleState.INSTALLED -> R.string.module_state_installed
+    ModuleState.ENABLED -> R.string.module_state_enabled
+    ModuleState.DISABLED -> R.string.module_state_disabled
+    ModuleState.INVALID -> R.string.module_state_invalid
+    ModuleState.INCOMPATIBLE -> R.string.module_state_incompatible
+    ModuleState.FAILED -> R.string.module_state_failed
+    ModuleState.ROLLED_BACK -> R.string.module_state_rolled_back
 }

--- a/app/src/main/kotlin/com/convx/music/ui/screens/settings/DeclarativeModuleHostSettingsScreen.kt
+++ b/app/src/main/kotlin/com/convx/music/ui/screens/settings/DeclarativeModuleHostSettingsScreen.kt
@@ -1,0 +1,110 @@
+package com.convx.music.ui.screens.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.convx.music.LocalPlayerAwareWindowInsets
+import com.convx.music.R
+import com.convx.music.modulehost.DeclarativeModuleHostViewModel
+import com.convx.modulehost.DeclarativeModuleHostLifecycle
+import com.convx.music.ui.component.IconButton
+import com.convx.music.ui.component.Material3SettingsGroup
+import com.convx.music.ui.component.Material3SettingsItem
+import com.convx.music.ui.utils.appTopBarWindowInsets
+import com.convx.music.ui.utils.backToMain
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeclarativeModuleHostSettingsScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    viewModel: DeclarativeModuleHostViewModel = hiltViewModel(),
+) {
+    val snapshot = viewModel.snapshot
+    val started = snapshot.lifecycle == DeclarativeModuleHostLifecycle.STARTED
+
+    Column(
+        Modifier
+            .windowInsetsPadding(
+                LocalPlayerAwareWindowInsets.current.only(
+                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                )
+            )
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp),
+    ) {
+        Spacer(
+            Modifier.windowInsetsPadding(
+                LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Top),
+            )
+        )
+        Material3SettingsGroup(
+            title = stringResource(R.string.declarative_modules),
+            items = listOf(
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.link),
+                    title = {
+                        Text(
+                            stringResource(
+                                if (started) R.string.module_host_ready else R.string.module_host_not_started,
+                            )
+                        )
+                    },
+                    description = {
+                        Text(stringResource(R.string.module_host_version, snapshot.convxVersion))
+                    },
+                ),
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.info),
+                    title = {
+                        Text(stringResource(R.string.module_host_registered_modules, snapshot.modules.size))
+                    },
+                    description = {
+                        Text(stringResource(R.string.module_host_no_installation))
+                    },
+                ),
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.security),
+                    title = { Text(stringResource(R.string.module_host_scope)) },
+                    enabled = false,
+                ),
+            ),
+        )
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.declarative_modules)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+        windowInsets = appTopBarWindowInsets(),
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/app/src/main/kotlin/com/convx/music/ui/screens/settings/SearchableSettings.kt
+++ b/app/src/main/kotlin/com/convx/music/ui/screens/settings/SearchableSettings.kt
@@ -55,6 +55,7 @@ fun getAllSearchableSettings(): List<SearchableSetting> {
         SearchableSetting("YouLyPlus", null, "Content", "settings/content"),
         SearchableSetting("PaxSenix", null, "Content", "settings/content"),
         SearchableSetting(stringResource(R.string.modules), null, "Content", "settings/modules"),
+        SearchableSetting(stringResource(R.string.declarative_modules), null, "Content", com.convx.music.modulehost.DeclarativeModuleHostRoutes.SETTINGS),
         SearchableSetting(stringResource(R.string.ai_lyrics_translation), null, "Content", "settings/ai"),
         SearchableSetting(stringResource(R.string.ai_api_key), null, "AI Lyrics Translation", "settings/ai"),
         SearchableSetting(stringResource(R.string.ai_model), null, "AI Lyrics Translation", "settings/ai"),

--- a/app/src/main/kotlin/com/convx/music/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/convx/music/ui/screens/settings/SettingsScreen.kt
@@ -229,6 +229,13 @@ fun SettingsScreen(
                 )
                 SettingsDivider()
                 SettingsNavItem(
+                    icon = painterResource(R.drawable.security),
+                    iconTint = Color(0xFF34C759),
+                    title = stringResource(R.string.declarative_modules),
+                    onClick = { navController.navigate(com.convx.music.modulehost.DeclarativeModuleHostRoutes.SETTINGS) },
+                )
+                SettingsDivider()
+                SettingsNavItem(
                     icon = painterResource(R.drawable.translate),
                     iconTint = Color(0xFFFF9500),
                     title = stringResource(R.string.ai_lyrics_translation),

--- a/app/src/main/res/values/vivi_strings.xml
+++ b/app/src/main/res/values/vivi_strings.xml
@@ -1274,6 +1274,15 @@
     <string name="library_icons_only">Library Icons Only</string>
     <string name="library_icons_only_desc">Show simple icons instead of artwork thumbnails in the library</string>
 
+    <!-- Declarative module host -->
+    <string name="declarative_modules">Declarative Modules</string>
+    <string name="module_host_ready">Module host ready</string>
+    <string name="module_host_not_started">Module host not started</string>
+    <string name="module_host_version">Convx %1$s</string>
+    <string name="module_host_registered_modules">Registered modules: %1$d</string>
+    <string name="module_host_no_installation">Package installation is not enabled yet.</string>
+    <string name="module_host_scope">Declarative packages only; no playback or executable code.</string>
+
     <string name="app_font">App Font</string>
     <string name="font_selection">Font Selection</string>
     <string name="font_additional">Additional Fonts</string>

--- a/app/src/main/res/values/vivi_strings.xml
+++ b/app/src/main/res/values/vivi_strings.xml
@@ -1279,9 +1279,25 @@
     <string name="module_host_ready">Module host ready</string>
     <string name="module_host_not_started">Module host not started</string>
     <string name="module_host_version">Convx %1$s</string>
-    <string name="module_host_registered_modules">Registered modules: %1$d</string>
-    <string name="module_host_no_installation">Package installation is not enabled yet.</string>
     <string name="module_host_scope">Declarative packages only; no playback or executable code.</string>
+    <string name="module_host_install">Install module</string>
+    <string name="module_host_install_hint">Pick a .smod package file</string>
+    <string name="module_host_installed_modules">Installed modules</string>
+    <string name="module_host_module_state">%1$s · %2$s</string>
+    <string name="module_host_remove">Remove</string>
+    <string name="module_host_remove_confirm_title">Remove module?</string>
+    <string name="module_host_remove_confirm_body">Uninstall %1$s from this device?</string>
+    <string name="module_host_error">Declarative module error</string>
+    <string name="module_state_discovered">Discovered</string>
+    <string name="module_state_validated">Validated</string>
+    <string name="module_state_staged">Staged</string>
+    <string name="module_state_installed">Installed</string>
+    <string name="module_state_enabled">Enabled</string>
+    <string name="module_state_disabled">Disabled</string>
+    <string name="module_state_invalid">Invalid</string>
+    <string name="module_state_incompatible">Incompatible</string>
+    <string name="module_state_failed">Failed</string>
+    <string name="module_state_rolled_back">Rolled back</string>
 
     <string name="app_font">App Font</string>
     <string name="font_selection">Font Selection</string>

--- a/app/src/test/kotlin/com/convx/music/modulehost/DeclarativeModuleHostIntegrationTest.kt
+++ b/app/src/test/kotlin/com/convx/music/modulehost/DeclarativeModuleHostIntegrationTest.kt
@@ -1,0 +1,19 @@
+package com.convx.music.modulehost
+
+import com.convx.modulehost.DeclarativeModuleHostLifecycle
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeclarativeModuleHostIntegrationTest {
+    @Test
+    fun `application host starts idempotently and exposes its settings route`() {
+        val host = ConvxDeclarativeModuleHost()
+
+        assertEquals(DeclarativeModuleHostLifecycle.NOT_STARTED, host.snapshot().lifecycle)
+        host.start()
+        host.start()
+
+        assertEquals(DeclarativeModuleHostLifecycle.STARTED, host.snapshot().lifecycle)
+        assertEquals("settings/declarative-modules", DeclarativeModuleHostRoutes.SETTINGS)
+    }
+}

--- a/app/src/test/kotlin/com/convx/music/modulehost/DeclarativeModuleHostIntegrationTest.kt
+++ b/app/src/test/kotlin/com/convx/music/modulehost/DeclarativeModuleHostIntegrationTest.kt
@@ -1,10 +1,21 @@
 package com.convx.music.modulehost
 
 import com.convx.modulehost.DeclarativeModuleHostLifecycle
+import com.convx.modulehost.ModuleState
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class DeclarativeModuleHostIntegrationTest {
+    @get:Rule
+    val temporary = TemporaryFolder()
+
     @Test
     fun `application host starts idempotently and exposes its settings route`() {
         val host = ConvxDeclarativeModuleHost()
@@ -15,5 +26,81 @@ class DeclarativeModuleHostIntegrationTest {
 
         assertEquals(DeclarativeModuleHostLifecycle.STARTED, host.snapshot().lifecycle)
         assertEquals("settings/declarative-modules", DeclarativeModuleHostRoutes.SETTINGS)
+    }
+
+    @Test
+    fun `store-backed host persists an installed module across restart`() {
+        val storeRoot = temporary.newFolder("modules").toPath()
+        val bytes = smodPackage()
+
+        val first = ConvxDeclarativeModuleHost()
+        first.start(storeRoot.toFile())
+        assertEquals(ModuleState.INSTALLED, first.install(bytes).modules.single().state)
+
+        val reloaded = ConvxDeclarativeModuleHost()
+        reloaded.start(storeRoot.toFile())
+        val module = reloaded.snapshot().modules.single()
+        assertEquals("spacemusic", module.manifest.id)
+        assertEquals(ModuleState.INSTALLED, module.state)
+    }
+
+    @Test
+    fun `module can be enabled disabled and removed through the app host`() {
+        val storeRoot = temporary.newFolder("modules2").toPath()
+        val host = ConvxDeclarativeModuleHost()
+        host.start(storeRoot.toFile())
+        host.install(smodPackage())
+
+        assertEquals(ModuleState.ENABLED, host.enable("spacemusic").modules.single().state)
+        assertEquals(ModuleState.DISABLED, host.disable("spacemusic").modules.single().state)
+
+        assertTrue(host.remove("spacemusic").modules.isEmpty())
+        assertTrue(Files.notExists(storeRoot.resolve("modules/spacemusic/current.smod")))
+    }
+
+    private fun smodPackage(): ByteArray {
+        val manifest = """
+            {
+              "${'$'}schema":"https://raw.githubusercontent.com/N7T0-OF/Spacemusic/main/schemas/manifest.schema.json",
+              "schemaVersion":"0.1",
+              "id":"spacemusic",
+              "name":"SpaceMusic",
+              "version":"0.1.0",
+              "type":"declarative",
+              "description":"A declarative music module for Convx.",
+              "author":"N7T0-OF",
+              "compatibility":{"minConvxVersion":"1.5.2","maxConvxVersion":null},
+              "permissions":["settings"],
+              "content":{"module":"module/module.json","icon":"assets/icon.svg"},
+              "updates":{"releaseIndex":"https://raw.githubusercontent.com/N7T0-OF/Spacemusic/main/releases/index.json"}
+            }
+        """.trimIndent()
+        val module = """
+            {
+              "${'$'}schema":"https://raw.githubusercontent.com/N7T0-OF/Spacemusic/main/schemas/module.schema.json",
+              "schemaVersion":"0.1",
+              "moduleId":"spacemusic",
+              "contributions":{
+                "settings":{
+                  "section":"SpaceMusic",
+                  "icon":"assets/icon.svg",
+                  "actions":[{"id":"check-updates","label":"Check for updates","action":"check-updates"}]
+                }
+              }
+            }
+        """.trimIndent()
+        val output = ByteArrayOutputStream()
+        ZipOutputStream(output).use { zip ->
+            zip.putNextEntry(ZipEntry("manifest.json"))
+            zip.write(manifest.toByteArray())
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("module/module.json"))
+            zip.write(module.toByteArray())
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("assets/icon.svg"))
+            zip.write("<svg xmlns=\"http://www.w3.org/2000/svg\"/>".toByteArray())
+            zip.closeEntry()
+        }
+        return output.toByteArray()
     }
 }

--- a/modulehost/build.gradle.kts
+++ b/modulehost/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(libs.ktor.serialization.json)
+    testImplementation(libs.junit)
+}

--- a/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleHost.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleHost.kt
@@ -1,0 +1,111 @@
+package com.convx.modulehost
+
+/**
+ * Declarative module host.
+ *
+ * Without a [ModuleStore] the host is in-memory only: registry state is lost on
+ * restart. With a store, every committed transition is persisted and package bytes
+ * are staged/committed atomically under the store root.
+ */
+class DeclarativeModuleHost(
+    val convxVersion: String,
+    private val store: ModuleStore? = null,
+) {
+    private val validator = DeclarativeModuleValidator(convxVersion)
+    private val registry = DeclarativeModuleRegistry(onChange = { modules -> store?.saveRegistry(modules) })
+    private var lifecycle = DeclarativeModuleHostLifecycle.NOT_STARTED
+
+    init {
+        if (store != null) {
+            registry.restore(store.loadRegistry())
+        }
+    }
+
+    @Synchronized
+    fun start() {
+        check(lifecycle == DeclarativeModuleHostLifecycle.NOT_STARTED) { "declarative module host is already started" }
+        lifecycle = DeclarativeModuleHostLifecycle.STARTED
+    }
+
+    @Synchronized
+    fun snapshot(): DeclarativeModuleHostSnapshot = DeclarativeModuleHostSnapshot(
+        lifecycle = lifecycle,
+        convxVersion = convxVersion,
+        modules = registry.snapshot(),
+    )
+
+    fun validate(packageBytes: ByteArray): ValidatedModulePackage = validator.validate(packageBytes)
+
+    @Synchronized
+    fun validateAndRegister(packageBytes: ByteArray): RegisteredModule {
+        checkStarted()
+        return registry.registerValidated(validate(packageBytes))
+    }
+
+    /**
+     * Atomically install or upgrade a registered module.
+     *
+     * [expectedSha256], when given, is verified before staging. The package is
+     * written to a staging slot, then committed; a failure restores the previous
+     * package bytes and marks the module [ModuleState.ROLLED_BACK] (or FAILED when
+     * there was no previous version).
+     */
+    @Synchronized
+    fun install(moduleId: String, packageBytes: ByteArray, expectedSha256: String? = null): RegisteredModule {
+        checkStarted()
+        expectedSha256?.let { ModuleIntegrity.verify(packageBytes, it) }
+        val validated = validate(packageBytes)
+        check(validated.manifest.id == moduleId) { "package manifest id does not match $moduleId" }
+
+        registry.stage(validated)
+        return try {
+            store?.stagePackage(moduleId, packageBytes)
+            store?.commitPackage(moduleId)
+            registry.commitInstall(moduleId)
+        } catch (error: Exception) {
+            runCatching { store?.rollbackPackage(moduleId) }
+            registry.failInstall(moduleId)
+            throw ModuleValidationException("install of $moduleId failed and was rolled back", error)
+        }
+    }
+
+    /** Restore the pre-upgrade package bytes and mark the module rolled back. */
+    @Synchronized
+    fun rollback(moduleId: String): RegisteredModule {
+        checkStarted()
+        val previousBytes = store?.previousPackage(moduleId)
+            ?: throw ModuleValidationException("module $moduleId has no previous version to roll back to")
+        // Revalidate before restoring: never restore bytes that no longer validate.
+        val previousManifest = validate(previousBytes).manifest
+        val restored = registry.rollback(moduleId, previousManifest)
+        store.rollbackPackage(moduleId)
+        return restored
+    }
+
+    @Synchronized
+    fun markInstalled(moduleId: String): RegisteredModule {
+        checkStarted()
+        return registry.markInstalled(moduleId)
+    }
+
+    @Synchronized
+    fun enable(moduleId: String): RegisteredModule {
+        checkStarted()
+        return registry.enable(moduleId)
+    }
+
+    @Synchronized
+    fun disable(moduleId: String): RegisteredModule {
+        checkStarted()
+        return registry.disable(moduleId)
+    }
+
+    @Synchronized
+    fun registered(moduleId: String): RegisteredModule? = registry.get(moduleId)
+
+    private fun checkStarted() {
+        check(lifecycle == DeclarativeModuleHostLifecycle.STARTED) {
+            "declarative module host has not been started"
+        }
+    }
+}

--- a/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleHost.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleHost.kt
@@ -36,10 +36,41 @@ class DeclarativeModuleHost(
 
     fun validate(packageBytes: ByteArray): ValidatedModulePackage = validator.validate(packageBytes)
 
+    /**
+     * Validate a package and register its module when not already registered.
+     * Registering an already-registered module is a no-op (an upgraded install
+     * keeps its existing registry entry until the staged commit replaces it).
+     */
     @Synchronized
     fun validateAndRegister(packageBytes: ByteArray): RegisteredModule {
         checkStarted()
-        return registry.registerValidated(validate(packageBytes))
+        val validated = validate(packageBytes)
+        val current = registry.get(validated.manifest.id)
+        return if (current == null) {
+            registry.registerValidated(validated)
+        } else {
+            current
+        }
+    }
+
+    /**
+     * Install a package that is not yet installed, registering it when needed:
+     * fresh package -> VALIDATED -> INSTALLED. Installing over an already
+     * installed/enabled/disabled module is rejected (use [install] to upgrade).
+     */
+    @Synchronized
+    fun installNew(packageBytes: ByteArray): RegisteredModule {
+        checkStarted()
+        val validated = validate(packageBytes)
+        val moduleId = validated.manifest.id
+        val current = registry.get(moduleId)
+        check(current == null || current.state == ModuleState.VALIDATED) {
+            "module $moduleId is already installed; upgrade with install()"
+        }
+        if (current == null) {
+            registry.registerValidated(validated)
+        }
+        return install(moduleId, packageBytes)
     }
 
     /**
@@ -98,6 +129,19 @@ class DeclarativeModuleHost(
     fun disable(moduleId: String): RegisteredModule {
         checkStarted()
         return registry.disable(moduleId)
+    }
+
+    /**
+     * Uninstall a module: drop its registry entry and, when a store is present,
+     * delete its package directory. Returns whether the module was registered.
+     */
+    @Synchronized
+    fun remove(moduleId: String): Boolean {
+        checkStarted()
+        if (registry.get(moduleId) == null) return false
+        registry.remove(moduleId)
+        store?.deleteModule(moduleId)
+        return true
     }
 
     @Synchronized

--- a/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleModels.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleModels.kt
@@ -1,0 +1,103 @@
+package com.convx.modulehost
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ModuleManifest(
+    @SerialName("${'$'}schema") val schema: String,
+    val schemaVersion: String,
+    val id: String,
+    val name: String,
+    val version: String,
+    val type: String,
+    val description: String,
+    val author: String,
+    val compatibility: ModuleCompatibility,
+    val permissions: List<String>,
+    val content: ModuleContent,
+    val updates: ModuleUpdates,
+)
+
+@Serializable
+data class ModuleCompatibility(
+    val minConvxVersion: String,
+    val maxConvxVersion: String?,
+)
+
+@Serializable
+data class ModuleContent(
+    val module: String,
+    val icon: String,
+)
+
+@Serializable
+data class ModuleUpdates(
+    val releaseIndex: String,
+)
+
+@Serializable
+data class ModuleDocument(
+    @SerialName("${'$'}schema") val schema: String,
+    val schemaVersion: String,
+    val moduleId: String,
+    val contributions: ModuleContributions,
+)
+
+@Serializable
+data class ModuleContributions(
+    val settings: SettingsContribution,
+)
+
+@Serializable
+data class SettingsContribution(
+    val section: String,
+    val icon: String,
+    val actions: List<SettingsAction>,
+)
+
+@Serializable
+data class SettingsAction(
+    val id: String,
+    val label: String,
+    val action: String,
+)
+
+data class ValidatedModulePackage(
+    val manifest: ModuleManifest,
+    val module: ModuleDocument,
+    val files: Map<String, ByteArray>,
+)
+
+enum class DeclarativeModuleHostLifecycle {
+    NOT_STARTED,
+    STARTED,
+}
+
+data class DeclarativeModuleHostSnapshot(
+    val lifecycle: DeclarativeModuleHostLifecycle,
+    val convxVersion: String,
+    val modules: List<RegisteredModule>,
+)
+
+enum class ModuleState {
+    DISCOVERED,
+    VALIDATED,
+    STAGED,
+    INSTALLED,
+    ENABLED,
+    DISABLED,
+    INVALID,
+    INCOMPATIBLE,
+    FAILED,
+    ROLLED_BACK,
+}
+
+@Serializable
+data class RegisteredModule(
+    val manifest: ModuleManifest,
+    val state: ModuleState,
+)
+
+class ModuleValidationException(message: String, cause: Throwable? = null) :
+    IllegalArgumentException(message, cause)

--- a/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleRegistry.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleRegistry.kt
@@ -105,6 +105,17 @@ class DeclarativeModuleRegistry(
         next = ModuleState.DISABLED,
     )
 
+    /** Forget a module entirely (uninstall). No-op when it is not registered. */
+    @Synchronized
+    fun remove(moduleId: String): Boolean {
+        val removed = modules.remove(moduleId) != null
+        if (removed) {
+            stagedPrevious.remove(moduleId)
+            onChange(snapshot())
+        }
+        return removed
+    }
+
     @Synchronized
     fun get(moduleId: String): RegisteredModule? = modules[moduleId]
 

--- a/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleRegistry.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleRegistry.kt
@@ -1,0 +1,147 @@
+package com.convx.modulehost
+
+/**
+ * In-memory module registry implementing the declared lifecycle state machine.
+ *
+ * [onChange] is invoked after every committed transition so an owner (the host) can
+ * persist state. Kotlin `@Synchronized` locks are reentrant, so the callback may
+ * safely call back into this registry (e.g. [snapshot]) without deadlock.
+ *
+ * Staged installs track the pre-install [RegisteredModule] so a failed commit can
+ * restore the previous manifest/version and mark the module [ModuleState.ROLLED_BACK].
+ */
+class DeclarativeModuleRegistry(
+    private val onChange: (List<RegisteredModule>) -> Unit = {},
+) {
+    private val modules = linkedMapOf<String, RegisteredModule>()
+    private val stagedPrevious = mutableMapOf<String, RegisteredModule>()
+
+    @Synchronized
+    fun registerValidated(module: ValidatedModulePackage): RegisteredModule {
+        val id = module.manifest.id
+        check(id !in modules) { "module is already registered: $id" }
+        val registered = RegisteredModule(module.manifest, ModuleState.VALIDATED)
+        modules[id] = registered
+        onChange(snapshot())
+        return registered
+    }
+
+    /** Begin an install/upgrade: VALIDATED, INSTALLED, or ROLLED_BACK -> STAGED. */
+    @Synchronized
+    fun stage(module: ValidatedModulePackage): RegisteredModule {
+        val id = module.manifest.id
+        val current = modules[id] ?: error("module is not registered: $id")
+        check(current.state in STAGEABLE) { "cannot stage ${current.state} module: $id" }
+        stagedPrevious[id] = current
+        val staged = RegisteredModule(module.manifest, ModuleState.STAGED)
+        modules[id] = staged
+        return staged
+    }
+
+    /** Commit a staged install: STAGED -> INSTALLED. */
+    @Synchronized
+    fun commitInstall(moduleId: String): RegisteredModule {
+        val staged = modules[moduleId] ?: error("module is not registered: $moduleId")
+        check(staged.state == ModuleState.STAGED) { "cannot commit ${staged.state} module: $moduleId" }
+        stagedPrevious.remove(moduleId)
+        val installed = staged.copy(state = ModuleState.INSTALLED)
+        modules[moduleId] = installed
+        onChange(snapshot())
+        return installed
+    }
+
+    /**
+     * Roll back a failed staged install. A failure while upgrading an installed
+     * module restores the previous manifest as ROLLED_BACK; a fresh install that
+     * never had a previous version becomes FAILED.
+     */
+    @Synchronized
+    fun failInstall(moduleId: String): RegisteredModule {
+        val current = modules[moduleId] ?: error("module is not registered: $moduleId")
+        check(current.state == ModuleState.STAGED) { "cannot fail ${current.state} module: $moduleId" }
+        val previous = stagedPrevious.remove(moduleId)
+        val restored = if (previous != null && previous.state != ModuleState.VALIDATED) {
+            previous.copy(state = ModuleState.ROLLED_BACK)
+        } else {
+            current.copy(state = ModuleState.FAILED)
+        }
+        modules[moduleId] = restored
+        onChange(snapshot())
+        return restored
+    }
+
+    /**
+     * Restore the pre-upgrade version with the previous manifest:
+     * INSTALLED/DISABLED/ENABLED -> ROLLED_BACK.
+     */
+    @Synchronized
+    fun rollback(moduleId: String, previousManifest: ModuleManifest): RegisteredModule {
+        val current = modules[moduleId] ?: error("module is not registered: $moduleId")
+        check(current.state in ROLLBACKABLE) { "cannot roll back ${current.state} module: $moduleId" }
+        val rolledBack = RegisteredModule(previousManifest, ModuleState.ROLLED_BACK)
+        modules[moduleId] = rolledBack
+        onChange(snapshot())
+        return rolledBack
+    }
+
+    @Synchronized
+    fun markInstalled(moduleId: String): RegisteredModule = transition(
+        moduleId,
+        allowed = setOf(ModuleState.VALIDATED),
+        next = ModuleState.INSTALLED,
+    )
+
+    @Synchronized
+    fun enable(moduleId: String): RegisteredModule = transition(
+        moduleId,
+        allowed = setOf(ModuleState.INSTALLED, ModuleState.DISABLED, ModuleState.ROLLED_BACK),
+        next = ModuleState.ENABLED,
+    )
+
+    @Synchronized
+    fun disable(moduleId: String): RegisteredModule = transition(
+        moduleId,
+        allowed = setOf(ModuleState.ENABLED),
+        next = ModuleState.DISABLED,
+    )
+
+    @Synchronized
+    fun get(moduleId: String): RegisteredModule? = modules[moduleId]
+
+    @Synchronized
+    fun snapshot(): List<RegisteredModule> = modules.values.toList()
+
+    @Synchronized
+    fun restore(modules: List<RegisteredModule>) {
+        this.modules.clear()
+        modules.forEach { this.modules[it.manifest.id] = it }
+    }
+
+    private fun transition(
+        moduleId: String,
+        allowed: Set<ModuleState>,
+        next: ModuleState,
+    ): RegisteredModule {
+        val current = modules[moduleId] ?: error("module is not registered: $moduleId")
+        check(current.state in allowed) {
+            "cannot transition $moduleId from ${current.state} to $next"
+        }
+        val updated = current.copy(state = next)
+        modules[moduleId] = updated
+        onChange(snapshot())
+        return updated
+    }
+
+    private companion object {
+        val STAGEABLE = setOf(
+            ModuleState.VALIDATED,
+            ModuleState.INSTALLED,
+            ModuleState.ROLLED_BACK,
+        )
+        val ROLLBACKABLE = setOf(
+            ModuleState.INSTALLED,
+            ModuleState.DISABLED,
+            ModuleState.ENABLED,
+        )
+    }
+}

--- a/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleValidator.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/DeclarativeModuleValidator.kt
@@ -1,0 +1,114 @@
+package com.convx.modulehost
+
+import java.net.URI
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+class DeclarativeModuleValidator(currentConvxVersion: String) {
+    private val currentConvxVersion = ModuleVersion.parse(currentConvxVersion, "Convx version")
+    private val json = Json {
+        ignoreUnknownKeys = false
+        isLenient = false
+        explicitNulls = true
+    }
+
+    fun validate(packageBytes: ByteArray): ValidatedModulePackage {
+        val files = ModulePackageReader.read(packageBytes)
+        val manifest = decode<ModuleManifest>(files.getValue("manifest.json"), "manifest.json")
+        checkManifest(manifest)
+        val module = decode<ModuleDocument>(files.getValue(manifest.content.module), manifest.content.module)
+        checkModule(manifest, module)
+        return ValidatedModulePackage(manifest, module, files)
+    }
+
+    private fun checkManifest(manifest: ModuleManifest) {
+        checkSchemaReference(manifest.schema, "manifest.schema.json", "manifest schema")
+        requireValid(manifest.schemaVersion == CONTRACT_VERSION, "unsupported module contract: ${manifest.schemaVersion}")
+        requireValid(manifest.type == "declarative", "manifest.type must be declarative")
+        requireValid(ID_PATTERN.matches(manifest.id), "manifest.id is invalid: ${manifest.id}")
+        requireValid(manifest.name.isNotBlank() && manifest.name.length <= 80, "manifest.name is invalid")
+        requireValid(manifest.description.isNotBlank() && manifest.description.length <= 280, "manifest.description is invalid")
+        requireValid(manifest.author.isNotBlank() && manifest.author.length <= 120, "manifest.author is invalid")
+        ModuleVersion.parse(manifest.version, "manifest.version")
+        checkCompatibility(manifest.compatibility, "manifest.compatibility")
+        requireValid(manifest.permissions.toSet() == SUPPORTED_PERMISSIONS && manifest.permissions.size == SUPPORTED_PERMISSIONS.size) {
+            "v0.1 permits only the settings permission"
+        }
+        requireValid(manifest.content.module == "module/module.json", "manifest.content.module must be module/module.json")
+        requireValid(manifest.content.icon == "assets/icon.svg", "manifest.content.icon must be assets/icon.svg")
+        checkHttpsUrl(manifest.updates.releaseIndex, "manifest.updates.releaseIndex")
+        requireValid(currentConvxVersion >= ModuleVersion.parse(manifest.compatibility.minConvxVersion, "manifest minimum")) {
+            "module is incompatible with this Convx version"
+        }
+        manifest.compatibility.maxConvxVersion?.let {
+            requireValid(currentConvxVersion <= ModuleVersion.parse(it, "manifest maximum")) {
+                "module is incompatible with this Convx version"
+            }
+        }
+    }
+
+    private fun checkModule(manifest: ModuleManifest, module: ModuleDocument) {
+        checkSchemaReference(module.schema, "module.schema.json", "module schema")
+        requireValid(module.schemaVersion == CONTRACT_VERSION, "unsupported module contract: ${module.schemaVersion}")
+        requireValid(module.moduleId == manifest.id, "module ID does not match manifest.id")
+        val settings = module.contributions.settings
+        requireValid(settings.section.isNotBlank() && settings.section.length <= 80, "Settings section is invalid")
+        requireValid(settings.icon == manifest.content.icon, "Settings icon must use the manifest icon")
+        requireValid(settings.actions.size == 1, "v0.1 requires exactly one Settings action")
+        val action = settings.actions.single()
+        requireValid(ACTION_ID_PATTERN.matches(action.id), "Settings action ID is invalid")
+        requireValid(action.id == "check-updates" && action.action == "check-updates") {
+            "v0.1 supports only the host-handled check-updates action"
+        }
+        requireValid(action.label.isNotBlank() && action.label.length <= 80, "Settings action label is invalid")
+    }
+
+    private fun checkCompatibility(value: ModuleCompatibility, label: String) {
+        val minimum = ModuleVersion.parse(value.minConvxVersion, "$label.minConvxVersion")
+        value.maxConvxVersion?.let {
+            requireValid(ModuleVersion.parse(it, "$label.maxConvxVersion") >= minimum) {
+                "$label maximum is older than minimum"
+            }
+        }
+    }
+
+    private fun checkSchemaReference(value: String, fileName: String, label: String) {
+        requireValid(value == SCHEMA_BASE_URL + fileName) {
+            "$label must reference the supplied $fileName schema"
+        }
+    }
+
+    private fun checkHttpsUrl(value: String, label: String) {
+        val uri = runCatching { URI(value) }.getOrNull()
+        requireValid(
+            uri != null && uri.scheme == "https" && !uri.host.isNullOrBlank() &&
+                value.all { !it.isWhitespace() },
+            "$label must be an HTTPS URL",
+        )
+    }
+
+    private inline fun <reified T> decode(bytes: ByteArray, label: String): T {
+        return try {
+            json.decodeFromString(bytes.decodeToString())
+        } catch (error: SerializationException) {
+            throw ModuleValidationException("$label is not valid module JSON", error)
+        }
+    }
+
+    private fun requireValid(condition: Boolean, message: String) {
+        if (!condition) throw ModuleValidationException(message)
+    }
+
+    private inline fun requireValid(condition: Boolean, message: () -> String) {
+        if (!condition) throw ModuleValidationException(message())
+    }
+
+    companion object {
+        const val CONTRACT_VERSION = "0.1"
+        private const val SCHEMA_BASE_URL =
+            "https://raw.githubusercontent.com/N7T0-OF/Spacemusic/main/schemas/"
+        private val ID_PATTERN = Regex("[a-z][a-z0-9-]{2,63}")
+        private val ACTION_ID_PATTERN = Regex("[a-z][a-z0-9-]{0,63}")
+        private val SUPPORTED_PERMISSIONS = setOf("settings")
+    }
+}

--- a/modulehost/src/main/kotlin/com/convx/modulehost/ModuleIntegrity.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/ModuleIntegrity.kt
@@ -1,0 +1,26 @@
+package com.convx.modulehost
+
+import java.security.MessageDigest
+
+/**
+ * SHA-256 integrity verification for module packages.
+ *
+ * A digest guarantees byte integrity only; it does not authenticate the publisher.
+ * Trusted-source/signature policy remains a host concern outside this class.
+ */
+object ModuleIntegrity {
+    private val hexPattern = Regex("[0-9A-Fa-f]{64}")
+
+    fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+    fun verify(bytes: ByteArray, expectedSha256: String) {
+        if (!hexPattern.matches(expectedSha256)) {
+            throw ModuleValidationException("sha256 must be exactly 64 hexadecimal characters")
+        }
+        val actual = sha256Hex(bytes)
+        if (actual != expectedSha256.lowercase()) {
+            throw ModuleValidationException("sha256 mismatch: expected $expectedSha256, got $actual")
+        }
+    }
+}

--- a/modulehost/src/main/kotlin/com/convx/modulehost/ModulePackageReader.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/ModulePackageReader.kt
@@ -1,0 +1,183 @@
+package com.convx.modulehost
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipInputStream
+
+object ModulePackageReader {
+    val packageFiles: Set<String> = setOf(
+        "manifest.json",
+        "module/module.json",
+        "assets/icon.svg",
+    )
+
+    private val safePath = Regex("[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*")
+
+    fun read(bytes: ByteArray): Map<String, ByteArray> {
+        validationRequire(bytes.isNotEmpty(), "module package is empty")
+
+        val centralDirectoryFiles = readCentralDirectoryFiles(bytes)
+        val contents = linkedMapOf<String, ByteArray>()
+        try {
+            ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+                while (true) {
+                    val entry = zip.nextEntry ?: break
+                    val name = entry.name
+                    requireSafePath(name)
+                    validationRequire(!entry.isDirectory, "module package contains a directory entry: $name")
+                    validationRequire(centralDirectoryFiles.remove(name), "module package entry is missing from its central directory: $name")
+                    validationRequire(name in packageFiles, "module package contains an undeclared path: $name")
+                    validationRequire(name !in contents, "module package contains a duplicate path: $name")
+                    contents[name] = readEntry(zip)
+                }
+            }
+        } catch (error: ModuleValidationException) {
+            throw error
+        } catch (error: Exception) {
+            throw ModuleValidationException("invalid .smod archive", error)
+        }
+
+        validationRequire(centralDirectoryFiles.isEmpty(), "module package central directory does not match its entries")
+        validationRequire(contents.keys == packageFiles) {
+            "module package must contain exactly ${packageFiles.sorted()}"
+        }
+        return contents.toMap()
+    }
+
+    private fun readCentralDirectoryFiles(bytes: ByteArray): MutableSet<String> {
+        val endOfCentralDirectory = findEndOfCentralDirectory(bytes)
+        validationRequire(endOfCentralDirectory >= 0, "module package has no ZIP end record")
+
+        val commentLength = readUnsignedShort(bytes, endOfCentralDirectory + 20)
+        validationRequire(endOfCentralDirectory.toLong() + END_OF_CENTRAL_DIRECTORY_SIZE + commentLength == bytes.size.toLong()) {
+            "module package has trailing data after the ZIP end record"
+        }
+
+        val diskNumber = readUnsignedShort(bytes, endOfCentralDirectory + 4)
+        val directoryDisk = readUnsignedShort(bytes, endOfCentralDirectory + 6)
+        val entriesOnDisk = readUnsignedShort(bytes, endOfCentralDirectory + 8)
+        val totalEntries = readUnsignedShort(bytes, endOfCentralDirectory + 10)
+        val directorySize = readUnsignedInt(bytes, endOfCentralDirectory + 12)
+        val directoryOffset = readUnsignedInt(bytes, endOfCentralDirectory + 16)
+        validationRequire(
+            diskNumber == 0 && directoryDisk == 0 && entriesOnDisk == totalEntries,
+            "module package uses multiple ZIP disks",
+        )
+        validationRequire(totalEntries != UINT16_MAX && directorySize != UINT32_MAX && directoryOffset != UINT32_MAX) {
+            "module package ZIP64 archives are not supported"
+        }
+
+        val directoryEnd = directoryOffset + directorySize
+        validationRequire(directoryOffset <= Int.MAX_VALUE && directoryEnd <= bytes.size.toLong()) {
+            "module package central directory is outside the archive"
+        }
+        validationRequire(directoryEnd == endOfCentralDirectory.toLong()) {
+            "module package central directory is not adjacent to the ZIP end record"
+        }
+
+        val files = linkedSetOf<String>()
+        var cursor = directoryOffset
+        repeat(totalEntries) {
+            validationRequire(cursor + CENTRAL_DIRECTORY_HEADER_SIZE <= directoryEnd) {
+                "module package central directory is truncated"
+            }
+            val headerOffset = cursor.toInt()
+            validationRequire(readUnsignedInt(bytes, headerOffset) == CENTRAL_DIRECTORY_SIGNATURE) {
+                "module package central directory is invalid"
+            }
+            val nameLength = readUnsignedShort(bytes, headerOffset + 28)
+            val extraLength = readUnsignedShort(bytes, headerOffset + 30)
+            val commentLength = readUnsignedShort(bytes, headerOffset + 32)
+            val nameStart = cursor + CENTRAL_DIRECTORY_HEADER_SIZE
+            val entryEnd = nameStart + nameLength + extraLength + commentLength
+            validationRequire(entryEnd <= directoryEnd) {
+                "module package central directory entry is truncated"
+            }
+            val name = bytes.copyOfRange(nameStart.toInt(), (nameStart + nameLength).toInt())
+                .toString(Charsets.UTF_8)
+            requireSafePath(name)
+            validationRequire(name in packageFiles, "module package contains an undeclared path: $name")
+            validationRequire(files.add(name), "module package contains a duplicate path: $name")
+
+            val externalAttributes = readUnsignedInt(bytes, headerOffset + 38)
+            val unixMode = ((externalAttributes ushr 16) and UINT16_MAX.toLong()).toInt()
+            val unixType = unixMode and UNIX_FILE_TYPE_MASK
+            validationRequire(externalAttributes and DOS_DIRECTORY_ATTRIBUTE.toLong() == 0L) {
+                "module package contains DOS directory metadata: $name"
+            }
+            validationRequire(unixType == 0 || unixType == UNIX_REGULAR_FILE) {
+                "module package contains a non-regular entry: $name"
+            }
+            cursor = entryEnd
+        }
+        validationRequire(cursor == directoryEnd) {
+            "module package central directory has unexpected data"
+        }
+        return files
+    }
+
+    private fun requireSafePath(name: String) {
+        validationRequire(name.isNotEmpty() && safePath.matches(name)) {
+            "unsafe module package path: ${name.toDebugString()}"
+        }
+        validationRequire(name.split('/').none { it == "." || it == ".." }) {
+            "module package path escapes its root: ${name.toDebugString()}"
+        }
+    }
+
+    private fun readEntry(zip: ZipInputStream): ByteArray {
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val count = zip.read(buffer)
+            if (count < 0) break
+            output.write(buffer, 0, count)
+        }
+        return output.toByteArray()
+    }
+
+    private fun findEndOfCentralDirectory(bytes: ByteArray): Int {
+        if (bytes.size < END_OF_CENTRAL_DIRECTORY_SIZE) return -1
+        val firstCandidate = maxOf(0, bytes.size - (END_OF_CENTRAL_DIRECTORY_SIZE + MAX_ZIP_COMMENT_SIZE))
+        for (offset in bytes.size - END_OF_CENTRAL_DIRECTORY_SIZE downTo firstCandidate) {
+            if (readUnsignedInt(bytes, offset) == END_OF_CENTRAL_DIRECTORY_SIGNATURE) return offset
+        }
+        return -1
+    }
+
+    private fun readUnsignedShort(bytes: ByteArray, offset: Int): Int {
+        validationRequire(offset >= 0 && offset + 2 <= bytes.size, "module package ZIP header is truncated")
+        return (bytes[offset].toInt() and 0xff) or
+            ((bytes[offset + 1].toInt() and 0xff) shl 8)
+    }
+
+    private fun readUnsignedInt(bytes: ByteArray, offset: Int): Long {
+        validationRequire(offset >= 0 && offset + 4 <= bytes.size, "module package ZIP header is truncated")
+        var value = 0L
+        repeat(4) { index ->
+            value = value or ((bytes[offset + index].toLong() and 0xff) shl (index * 8))
+        }
+        return value
+    }
+
+    private fun validationRequire(condition: Boolean, message: () -> String) {
+        if (!condition) throw ModuleValidationException(message())
+    }
+
+    private fun validationRequire(condition: Boolean, message: String) {
+        if (!condition) throw ModuleValidationException(message)
+    }
+
+    private fun String.toDebugString(): String = replace("\u0000", "\\0")
+
+    private const val CENTRAL_DIRECTORY_HEADER_SIZE = 46L
+    private const val END_OF_CENTRAL_DIRECTORY_SIZE = 22
+    private const val MAX_ZIP_COMMENT_SIZE = 0xffff
+    private const val CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50L
+    private const val END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50L
+    private const val DOS_DIRECTORY_ATTRIBUTE = 0x10
+    private const val UNIX_FILE_TYPE_MASK = 0xf000
+    private const val UNIX_REGULAR_FILE = 0x8000
+    private const val UINT16_MAX = 0xffff
+    private const val UINT32_MAX = 0xffff_ffffL
+}

--- a/modulehost/src/main/kotlin/com/convx/modulehost/ModuleStore.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/ModuleStore.kt
@@ -1,0 +1,105 @@
+package com.convx.modulehost
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * File-backed persistence for the declarative module host.
+ *
+ * Layout under [root]:
+ *   registry.json                      - serialized [RegisteredModule] list
+ *   modules/<id>/current.smod          - installed package bytes
+ *   modules/<id>/previous.smod         - pre-upgrade package bytes (rollback point)
+ *   modules/<id>/staged.smod           - in-progress install, removed on commit/rollback
+ *
+ * Every write goes through a temp file followed by an atomic-or-replacing move, so a
+ * reader never observes a partially written file. Per-operation atomicity is guaranteed;
+ * cross-file crash consistency (registry vs package bytes) is deliberately out of scope
+ * for v0.1 and is repaired by revalidation on the next host start.
+ */
+class ModuleStore(private val root: Path) {
+    private val registryFile = root.resolve("registry.json")
+    private val json = Json {
+        ignoreUnknownKeys = false
+        isLenient = false
+        explicitNulls = true
+    }
+
+    fun saveRegistry(modules: List<RegisteredModule>) {
+        val bytes = json.encodeToString(ListSerializer(RegisteredModule.serializer()), modules)
+            .encodeToByteArray()
+        writeAtomic(registryFile, bytes)
+    }
+
+    fun loadRegistry(): List<RegisteredModule> {
+        if (!Files.exists(registryFile)) return emptyList()
+        return runCatching {
+            json.decodeFromString(ListSerializer(RegisteredModule.serializer()), Files.readString(registryFile))
+        }.getOrElse { error ->
+            throw ModuleValidationException("module store registry is corrupt", error)
+        }
+    }
+
+    fun currentPackage(moduleId: String): ByteArray? = readIfExists(packagePath(moduleId, "current.smod"))
+
+    fun previousPackage(moduleId: String): ByteArray? = readIfExists(packagePath(moduleId, "previous.smod"))
+
+    fun stagePackage(moduleId: String, bytes: ByteArray) = writeAtomic(packagePath(moduleId, "staged.smod"), bytes)
+
+    fun commitPackage(moduleId: String) {
+        val directory = moduleDir(moduleId)
+        Files.createDirectories(directory)
+        val current = directory.resolve("current.smod")
+        val previous = directory.resolve("previous.smod")
+        val staged = directory.resolve("staged.smod")
+        if (Files.exists(current)) {
+            moveReplacing(current, previous)
+        }
+        moveReplacing(staged, current)
+    }
+
+    fun rollbackPackage(moduleId: String) {
+        val directory = moduleDir(moduleId)
+        val previous = directory.resolve("previous.smod")
+        // Restore the pre-upgrade bytes only when a backup exists; a failure before
+        // commit must never remove the currently installed package.
+        if (Files.exists(previous)) {
+            moveReplacing(previous, directory.resolve("current.smod"))
+        }
+        val staged = directory.resolve("staged.smod")
+        Files.deleteIfExists(staged)
+        Files.deleteIfExists(staged.resolveSibling("staged.smod.tmp"))
+    }
+
+    private fun packagePath(moduleId: String, fileName: String): Path {
+        require(SAFE_MODULE_ID.matches(moduleId)) { "unsafe module id for storage: $moduleId" }
+        return moduleDir(moduleId).resolve(fileName)
+    }
+
+    private fun moduleDir(moduleId: String): Path = root.resolve("modules").resolve(moduleId)
+
+    private fun writeAtomic(target: Path, bytes: ByteArray) {
+        Files.createDirectories(target.parent)
+        val temporary = target.resolveSibling(target.fileName.toString() + ".tmp")
+        Files.write(temporary, bytes)
+        moveReplacing(temporary, target)
+    }
+
+    private fun moveReplacing(source: Path, target: Path) {
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        } catch (error: Exception) {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    private fun readIfExists(path: Path): ByteArray? =
+        if (Files.exists(path)) Files.readAllBytes(path) else null
+
+    private companion object {
+        val SAFE_MODULE_ID = Regex("[a-z][a-z0-9-]{2,63}")
+    }
+}

--- a/modulehost/src/main/kotlin/com/convx/modulehost/ModuleStore.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/ModuleStore.kt
@@ -61,6 +61,16 @@ class ModuleStore(private val root: Path) {
         moveReplacing(staged, current)
     }
 
+    /** Delete every stored artifact for a module (uninstall). */
+    fun deleteModule(moduleId: String) {
+        val dir = moduleDir(moduleId)
+        if (Files.isDirectory(dir)) {
+            Files.walk(dir).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach(Files::delete)
+            }
+        }
+    }
+
     fun rollbackPackage(moduleId: String) {
         val directory = moduleDir(moduleId)
         val previous = directory.resolve("previous.smod")

--- a/modulehost/src/main/kotlin/com/convx/modulehost/ModuleUpdater.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/ModuleUpdater.kt
@@ -1,0 +1,72 @@
+package com.convx.modulehost
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class ModuleRelease(
+    @SerialName("${'$'}schema") val schema: String,
+    val schemaVersion: String,
+    val moduleId: String,
+    val version: String,
+    val status: String,
+    val compatibility: ModuleCompatibility,
+    val artifact: String?,
+    val sha256: String?,
+    val notes: String,
+)
+
+@Serializable
+data class ReleaseIndex(
+    @SerialName("${'$'}schema") val schema: String,
+    val schemaVersion: String,
+    val moduleId: String,
+    val releases: List<ModuleRelease>,
+)
+
+/**
+ * Minimal updater over the SpaceMusic release-index contract.
+ *
+ * Selection is declarative: only `published` releases whose compatibility range
+ * includes the running Convx version are candidates, and the newest SemVer wins.
+ * The host still owns downloading, network policy, and trusted-source policy;
+ * this class only parses the feed and verifies an artifact's declared SHA-256.
+ */
+class ModuleUpdater(private val currentConvxVersion: String) {
+    private val currentVersion = ModuleVersion.parse(currentConvxVersion, "Convx version")
+    private val json = Json {
+        ignoreUnknownKeys = false
+        isLenient = false
+        explicitNulls = true
+    }
+
+    fun latestRelease(indexBytes: ByteArray, moduleId: String): ModuleRelease? {
+        val index = try {
+            json.decodeFromString<ReleaseIndex>(indexBytes.decodeToString())
+        } catch (error: Exception) {
+            throw ModuleValidationException("release index is not valid release JSON", error)
+        }
+        if (index.schemaVersion != "0.1") {
+            throw ModuleValidationException("unsupported release index contract: ${index.schemaVersion}")
+        }
+        // A feed that does not describe this module has no candidates for it.
+        if (index.moduleId != moduleId) return null
+        return index.releases
+            .filter { it.moduleId == moduleId }
+            .filter { it.status == "published" }
+            .filter { release ->
+                val minimum = ModuleVersion.parse(release.compatibility.minConvxVersion, "release minimum")
+                val maximum = release.compatibility.maxConvxVersion
+                    ?.let { ModuleVersion.parse(it, "release maximum") }
+                currentVersion >= minimum && (maximum == null || currentVersion <= maximum)
+            }
+            .maxByOrNull { ModuleVersion.parse(it.version, "release version") }
+    }
+
+    fun verifyArtifact(release: ModuleRelease, artifactBytes: ByteArray) {
+        val digest = release.sha256
+            ?: throw ModuleValidationException("published release ${release.version} has no sha256")
+        ModuleIntegrity.verify(artifactBytes, digest)
+    }
+}

--- a/modulehost/src/main/kotlin/com/convx/modulehost/ModuleVersion.kt
+++ b/modulehost/src/main/kotlin/com/convx/modulehost/ModuleVersion.kt
@@ -1,0 +1,57 @@
+package com.convx.modulehost
+
+import java.math.BigInteger
+
+internal class ModuleVersion private constructor(
+    private val major: BigInteger,
+    private val minor: BigInteger,
+    private val patch: BigInteger,
+    private val preRelease: List<String>?,
+) : Comparable<ModuleVersion> {
+    override fun compareTo(other: ModuleVersion): Int {
+        for ((left, right) in listOf(major to other.major, minor to other.minor, patch to other.patch)) {
+            val comparison = left.compareTo(right)
+            if (comparison != 0) return comparison
+        }
+
+        val leftPreRelease = preRelease
+        val rightPreRelease = other.preRelease
+        if (leftPreRelease == null || rightPreRelease == null) {
+            return when {
+                leftPreRelease == rightPreRelease -> 0
+                leftPreRelease == null -> 1
+                else -> -1
+            }
+        }
+
+        for ((left, right) in leftPreRelease.zip(rightPreRelease)) {
+            if (left == right) continue
+            val leftNumeric = left.all(Char::isDigit)
+            val rightNumeric = right.all(Char::isDigit)
+            return when {
+                leftNumeric && rightNumeric -> BigInteger(left).compareTo(BigInteger(right))
+                leftNumeric != rightNumeric -> if (leftNumeric) -1 else 1
+                else -> left.compareTo(right)
+            }
+        }
+        return leftPreRelease.size.compareTo(rightPreRelease.size)
+    }
+
+    companion object {
+        private val pattern = Regex(
+            """^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$""",
+        )
+
+        fun parse(value: String, label: String): ModuleVersion {
+            val match = pattern.matchEntire(value)
+                ?: throw ModuleValidationException("$label must be valid SemVer")
+            val (major, minor, patch, preRelease) = match.destructured
+            return ModuleVersion(
+                major = BigInteger(major),
+                minor = BigInteger(minor),
+                patch = BigInteger(patch),
+                preRelease = preRelease.takeIf(String::isNotEmpty)?.split('.'),
+            )
+        }
+    }
+}

--- a/modulehost/src/test/kotlin/com/convx/modulehost/DeclarativeModuleHostTest.kt
+++ b/modulehost/src/test/kotlin/com/convx/modulehost/DeclarativeModuleHostTest.kt
@@ -1,0 +1,272 @@
+package com.convx.modulehost
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeclarativeModuleHostTest {
+    @Test
+    fun `valid declarative package validates and follows registry lifecycle`() {
+        val host = DeclarativeModuleHost("1.5.2")
+        host.start()
+
+        val registered = host.validateAndRegister(TestModulePackages.packageBytes())
+        assertEquals("spacemusic", registered.manifest.id)
+        assertEquals(ModuleState.VALIDATED, registered.state)
+
+        assertEquals(ModuleState.INSTALLED, host.markInstalled("spacemusic").state)
+        assertEquals(ModuleState.ENABLED, host.enable("spacemusic").state)
+        assertEquals(ModuleState.DISABLED, host.disable("spacemusic").state)
+        assertEquals(listOf(ModuleState.DISABLED), host.snapshot().modules.map { it.state })
+    }
+
+    @Test
+    fun `archive reader accepts regular files and rejects unsafe or non-regular entries`() {
+        val expected = TestModulePackages.packageEntries()
+        assertPackageContents(expected, ModulePackageReader.read(TestModulePackages.zip(expected)))
+        assertPackageContents(
+            expected,
+            ModulePackageReader.read(metadataArchive(expected, UNIX_REGULAR_MODE, "manifest.json")),
+        )
+
+        listOf(
+            TestModulePackages.zip(expected + ("../escape.json" to "bad".encodeToByteArray())),
+            TestModulePackages.zip(expected + ("/manifest.json" to "bad".encodeToByteArray())),
+            TestModulePackages.zip(expected + ("module\\\\module.json" to "bad".encodeToByteArray())),
+            duplicateManifestArchive(expected),
+            TestModulePackages.zip(expected + ("README.md" to "bad".encodeToByteArray())),
+            metadataArchive(expected, DOS_DIRECTORY_ATTRIBUTE, "manifest.json"),
+            metadataArchive(expected, UNIX_SYMLINK_MODE, "assets/icon.svg"),
+            malformedCentralDirectoryArchive(expected),
+            centralDirectoryGapArchive(expected),
+        ).forEach { archive ->
+            assertRejected { ModulePackageReader.read(archive) }
+        }
+    }
+
+    @Test
+    fun `host lifecycle starts once and gates registration`() {
+        val host = DeclarativeModuleHost("1.5.2")
+
+        assertEquals(DeclarativeModuleHostLifecycle.NOT_STARTED, host.snapshot().lifecycle)
+        assertStateRejected { host.validateAndRegister(TestModulePackages.packageBytes()) }
+
+        host.start()
+        assertEquals(DeclarativeModuleHostLifecycle.STARTED, host.snapshot().lifecycle)
+        assertStateRejected { host.start() }
+    }
+
+    @Test
+    fun `package reader rejects empty and malformed archives`() {
+        assertRejected { ModulePackageReader.read(byteArrayOf()) }
+        assertRejected { ModulePackageReader.read("not a zip".encodeToByteArray()) }
+    }
+
+    @Test
+    fun `validator rejects non-declarative module types`() {
+        assertRejected {
+            DeclarativeModuleHost("1.5.2").validate(
+                TestModulePackages.packageBytes(
+                    manifest = TestModulePackages.manifestJson(type = "executable"),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `validator rejects unsupported permissions and actions`() {
+        assertRejected {
+            DeclarativeModuleHost("1.5.2").validate(
+                TestModulePackages.packageBytes(
+                    manifest = TestModulePackages.manifestJson(permissions = "[\"settings\",\"network\"]"),
+                ),
+            )
+        }
+        assertRejected {
+            DeclarativeModuleHost("1.5.2").validate(
+                TestModulePackages.packageBytes(
+                    module = TestModulePackages.moduleJson(action = "open"),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `validator rejects module identity and incompatible Convx versions`() {
+        assertRejected {
+            DeclarativeModuleHost("1.5.2").validate(
+                TestModulePackages.packageBytes(
+                    module = TestModulePackages.moduleJson(moduleId = "other-module"),
+                ),
+            )
+        }
+        assertRejected {
+            DeclarativeModuleHost("1.5.1").validate(TestModulePackages.packageBytes())
+        }
+    }
+
+    @Test
+    fun `validator rejects manifest identity compatibility and schema boundaries`() {
+        listOf(
+            TestModulePackages.manifestJson(id = "SpaceMusic"),
+            TestModulePackages.manifestJson(compatibility = """{"minConvxVersion":"1.5.2","maxConvxVersion":"1.5.1"}"""),
+            TestModulePackages.manifestJson(compatibility = """{"minConvxVersion":"1.0.0","maxConvxVersion":"1.5.1"}"""),
+            TestModulePackages.manifestJson(schema = "${TestModulePackages.SCHEMA_BASE}other.schema.json"),
+        ).forEach { manifest ->
+            assertRejected {
+                DeclarativeModuleHost("1.5.2").validate(TestModulePackages.packageBytes(manifest = manifest))
+            }
+        }
+        assertRejected {
+            DeclarativeModuleHost("1.5.2").validate(
+                TestModulePackages.packageBytes(
+                    module = TestModulePackages.moduleJson(schema = "${TestModulePackages.SCHEMA_BASE}other.schema.json"),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `validator rejects malformed JSON SemVer and unknown manifest fields`() {
+        listOf(
+            "{",
+            TestModulePackages.manifestJson(version = "0.1"),
+            TestModulePackages.manifestJson(extra = ",\"unknown\":true"),
+        ).forEach { manifest ->
+            assertRejected {
+                DeclarativeModuleHost("1.5.2").validate(TestModulePackages.packageBytes(manifest = manifest))
+            }
+        }
+    }
+
+    @Test
+    fun `registry does not enable a module before installation`() {
+        val host = DeclarativeModuleHost("1.5.2")
+        host.start()
+        host.validateAndRegister(TestModulePackages.packageBytes())
+
+        assertStateRejected { host.enable("spacemusic") }
+        assertTrue(host.registered("spacemusic")?.state == ModuleState.VALIDATED)
+    }
+
+    private fun assertPackageContents(expected: Map<String, ByteArray>, actual: Map<String, ByteArray>) {
+        assertEquals(expected.keys, actual.keys)
+        expected.forEach { (name, payload) ->
+            assertTrue("archive payload differs for $name", payload.contentEquals(actual.getValue(name)))
+        }
+    }
+
+    private fun assertRejected(block: () -> Unit) {
+        try {
+            block()
+        } catch (_: ModuleValidationException) {
+            return
+        }
+        throw AssertionError("invalid module input was accepted")
+    }
+
+    private fun assertStateRejected(block: () -> Unit) {
+        try {
+            block()
+        } catch (_: IllegalStateException) {
+            return
+        }
+        throw AssertionError("invalid state transition was accepted")
+    }
+
+    private fun metadataArchive(
+        entries: Map<String, ByteArray>,
+        externalAttributes: Int,
+        target: String,
+    ): ByteArray {
+        val archive = TestModulePackages.zip(entries)
+        val targetBytes = target.encodeToByteArray()
+        var offset = 0
+        var patched = false
+        while (offset + CENTRAL_DIRECTORY_HEADER_SIZE <= archive.size) {
+            if (readLittleEndianInt(archive, offset) != CENTRAL_DIRECTORY_SIGNATURE) {
+                offset++
+                continue
+            }
+            val nameLength = readLittleEndianShort(archive, offset + 28)
+            val extraLength = readLittleEndianShort(archive, offset + 30)
+            val commentLength = readLittleEndianShort(archive, offset + 32)
+            val nameStart = offset + CENTRAL_DIRECTORY_HEADER_SIZE
+            val entryEnd = nameStart + nameLength + extraLength + commentLength
+            if (entryEnd > archive.size) break
+            if (targetBytes.contentEquals(archive.copyOfRange(nameStart, nameStart + nameLength))) {
+                writeLittleEndianInt(archive, offset + EXTERNAL_ATTRIBUTES_OFFSET, externalAttributes)
+                patched = true
+                break
+            }
+            offset = entryEnd
+        }
+        assertTrue("target archive entry was not found", patched)
+        return archive
+    }
+
+    private fun readLittleEndianShort(bytes: ByteArray, offset: Int): Int =
+        (bytes[offset].toInt() and 0xff) or
+            ((bytes[offset + 1].toInt() and 0xff) shl 8)
+
+    private fun readLittleEndianInt(bytes: ByteArray, offset: Int): Int =
+        readLittleEndianShort(bytes, offset) or
+            (readLittleEndianShort(bytes, offset + 2) shl 16)
+
+    private fun writeLittleEndianInt(bytes: ByteArray, offset: Int, value: Int) {
+        repeat(4) { index ->
+            bytes[offset + index] = (value ushr (index * 8)).toByte()
+        }
+    }
+
+    private fun malformedCentralDirectoryArchive(entries: Map<String, ByteArray>): ByteArray {
+        val archive = TestModulePackages.zip(entries)
+        var offset = 0
+        while (offset + 4 <= archive.size && readLittleEndianInt(archive, offset) != CENTRAL_DIRECTORY_SIGNATURE) {
+            offset++
+        }
+        assertTrue("central directory was not found", offset + 4 <= archive.size)
+        writeLittleEndianInt(archive, offset, 0)
+        return archive
+    }
+
+    private fun centralDirectoryGapArchive(entries: Map<String, ByteArray>): ByteArray {
+        val archive = TestModulePackages.zip(entries)
+        var endOffset = 0
+        while (endOffset + 4 <= archive.size && readLittleEndianInt(archive, endOffset) != END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
+            endOffset++
+        }
+        assertTrue("ZIP end record was not found", endOffset + 4 <= archive.size)
+        val gap = byteArrayOf(0x55, 0x66, 0x77)
+        return archive.copyOf(archive.size + gap.size).also { malformed ->
+            archive.copyInto(malformed, endOffset + gap.size, endOffset)
+            gap.copyInto(malformed, endOffset)
+        }
+    }
+
+    private fun duplicateManifestArchive(entries: Map<String, ByteArray>): ByteArray {
+        val archive = TestModulePackages.zipEntries(
+            entries.entries.map { it.key to it.value } +
+                ("manifest.jsox" to entries.getValue("manifest.json")),
+        )
+        val source = "manifest.jsox".encodeToByteArray()
+        val replacement = "manifest.json".encodeToByteArray()
+        return archive.copyOf().also { bytes ->
+            for (offset in 0..bytes.size - source.size) {
+                if (source.indices.all { index -> bytes[offset + index] == source[index] }) {
+                    replacement.copyInto(bytes, offset)
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50
+        const val END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50
+        const val CENTRAL_DIRECTORY_HEADER_SIZE = 46
+        const val EXTERNAL_ATTRIBUTES_OFFSET = 38
+        const val DOS_DIRECTORY_ATTRIBUTE = 0x10
+        val UNIX_REGULAR_MODE = (0x8000 or 0x1A4) shl 16
+        val UNIX_SYMLINK_MODE = (0xA000 or 0x1FF) shl 16
+    }
+}

--- a/modulehost/src/test/kotlin/com/convx/modulehost/DeclarativeModuleLifecycleTest.kt
+++ b/modulehost/src/test/kotlin/com/convx/modulehost/DeclarativeModuleLifecycleTest.kt
@@ -119,6 +119,21 @@ class DeclarativeModuleLifecycleTest {
     }
 
     @Test
+    fun `installNew registers a fresh package and remove uninstalls it`() {
+        val store = ModuleStore(temporary.newFolder("store").toPath())
+        val host = DeclarativeModuleHost("1.5.2", store)
+        host.start()
+        val bytes = TestModulePackages.packageBytes()
+
+        assertEquals(ModuleState.INSTALLED, host.installNew(bytes).state)
+        assertStateRejected { host.installNew(bytes) }
+        assertTrue("remove must report the module was present", host.remove("spacemusic"))
+        assertTrue(host.snapshot().modules.isEmpty())
+        assertEquals("store must forget the package bytes", null, store.currentPackage("spacemusic"))
+        assertTrue("removing an unknown module is a no-op", !host.remove("spacemusic"))
+    }
+
+    @Test
     fun `registry rejects invalid staged lifecycle transitions`() {
         val registry = DeclarativeModuleRegistry()
         val host = DeclarativeModuleHost("1.5.2")

--- a/modulehost/src/test/kotlin/com/convx/modulehost/DeclarativeModuleLifecycleTest.kt
+++ b/modulehost/src/test/kotlin/com/convx/modulehost/DeclarativeModuleLifecycleTest.kt
@@ -1,0 +1,210 @@
+package com.convx.modulehost
+
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DeclarativeModuleLifecycleTest {
+    @get:Rule
+    val temporary = TemporaryFolder()
+
+    @Test
+    fun `host persists registry and package bytes across restarts`() {
+        val store = ModuleStore(temporary.newFolder("store").toPath())
+        val bytes = TestModulePackages.packageBytes()
+
+        val first = DeclarativeModuleHost("1.5.2", store)
+        first.start()
+        first.validateAndRegister(bytes)
+        first.install("spacemusic", bytes)
+        first.enable("spacemusic")
+        assertEquals(ModuleState.ENABLED, first.registered("spacemusic")?.state)
+
+        val reloaded = DeclarativeModuleHost("1.5.2", store)
+        reloaded.start()
+        assertEquals(ModuleState.ENABLED, reloaded.registered("spacemusic")?.state)
+        assertTrue("package bytes must survive restart", store.currentPackage("spacemusic")!!.contentEquals(bytes))
+    }
+
+    @Test
+    fun `install verifies sha256 and rejects a mismatched digest without side effects`() {
+        val store = ModuleStore(temporary.newFolder("store").toPath())
+        val host = DeclarativeModuleHost("1.5.2", store)
+        host.start()
+        val bytes = TestModulePackages.packageBytes()
+        host.validateAndRegister(bytes)
+
+        val expected = ModuleIntegrity.sha256Hex(bytes)
+        assertEquals(ModuleState.INSTALLED, host.install("spacemusic", bytes, expected).state)
+
+        val different = TestModulePackages.packageBytes(
+            manifest = TestModulePackages.manifestJson(version = "0.1.1"),
+        )
+        assertRejected {
+            host.install("spacemusic", different, expected)
+        }
+        assertEquals("failed upgrade must leave the installed version untouched", "0.1.0",
+            host.registered("spacemusic")?.manifest?.version)
+        assertTrue(store.currentPackage("spacemusic")!!.contentEquals(bytes))
+    }
+
+    @Test
+    fun `install rejects a malformed sha256 before staging`() {
+        val host = DeclarativeModuleHost("1.5.2")
+        host.start()
+        host.validateAndRegister(TestModulePackages.packageBytes())
+        assertRejected {
+            host.install("spacemusic", TestModulePackages.packageBytes(), "not-a-hex-digest")
+        }
+        assertEquals(ModuleState.VALIDATED, host.registered("spacemusic")?.state)
+    }
+
+    @Test
+    fun `upgrade keeps the previous version and rollback restores it`() {
+        val store = ModuleStore(temporary.newFolder("store").toPath())
+        val host = DeclarativeModuleHost("1.5.2", store)
+        host.start()
+        val v0 = TestModulePackages.packageBytes()
+        host.validateAndRegister(v0)
+        host.install("spacemusic", v0)
+
+        val v1 = TestModulePackages.packageBytes(
+            manifest = TestModulePackages.manifestJson(version = "0.1.1"),
+        )
+        assertEquals("0.1.1", host.install("spacemusic", v1).manifest.version)
+        assertTrue("previous package must be retained", store.previousPackage("spacemusic")!!.contentEquals(v0))
+
+        val rolledBack = host.rollback("spacemusic")
+        assertEquals(ModuleState.ROLLED_BACK, rolledBack.state)
+        assertEquals("0.1.0", rolledBack.manifest.version)
+        assertTrue("rollback must restore the previous bytes", store.currentPackage("spacemusic")!!.contentEquals(v0))
+    }
+
+    @Test
+    fun `failed staged install rolls back to the previous version`() {
+        val store = ModuleStore(temporary.newFolder("store").toPath())
+        val host = DeclarativeModuleHost("1.5.2", store)
+        host.start()
+        val v0 = TestModulePackages.packageBytes()
+        host.validateAndRegister(v0)
+        host.install("spacemusic", v0)
+
+        // Force the staging write to fail: a non-empty directory named staged.smod
+        // cannot be replaced by the staged file on any platform.
+        val moduleDir = temporary.root.toPath().resolve("store").resolve("modules").resolve("spacemusic")
+        Files.createDirectories(moduleDir.resolve("staged.smod"))
+        Files.writeString(moduleDir.resolve("staged.smod").resolve("blocker"), "x")
+
+        val v1 = TestModulePackages.packageBytes(
+            manifest = TestModulePackages.manifestJson(version = "0.1.1"),
+        )
+        assertRejected { host.install("spacemusic", v1) }
+        assertEquals(ModuleState.ROLLED_BACK, host.registered("spacemusic")?.state)
+        assertEquals("0.1.0", host.registered("spacemusic")?.manifest?.version)
+        assertTrue("failed upgrade must keep the installed bytes", store.currentPackage("spacemusic")!!.contentEquals(v0))
+    }
+
+    @Test
+    fun `rollback without a previous version is rejected`() {
+        val store = ModuleStore(temporary.newFolder("store").toPath())
+        val host = DeclarativeModuleHost("1.5.2", store)
+        host.start()
+        host.validateAndRegister(TestModulePackages.packageBytes())
+        host.install("spacemusic", TestModulePackages.packageBytes())
+        assertRejected { host.rollback("spacemusic") }
+    }
+
+    @Test
+    fun `registry rejects invalid staged lifecycle transitions`() {
+        val registry = DeclarativeModuleRegistry()
+        val host = DeclarativeModuleHost("1.5.2")
+        host.start()
+        val validated = host.validate(TestModulePackages.packageBytes())
+        registry.registerValidated(validated)
+
+        // A brand-new module that fails while staged has no previous version: FAILED.
+        registry.stage(validated)
+        assertEquals(ModuleState.FAILED, registry.failInstall("spacemusic").state)
+        assertStateRejected { registry.failInstall("spacemusic") }
+        assertStateRejected { registry.commitInstall("spacemusic") }
+    }
+
+    @Test
+    fun `updater selects the newest published compatible release`() {
+        val updater = ModuleUpdater("1.5.2")
+        val digest = "ab".repeat(32)
+        val index = TestModulePackages.releaseIndex(
+            releases = listOf(
+                TestModulePackages.releaseJson(version = "0.1.0", sha256 = digest),
+                TestModulePackages.releaseJson(
+                    version = "0.2.0",
+                    status = "draft",
+                    artifact = null,
+                    sha256 = null,
+                ),
+                TestModulePackages.releaseJson(
+                    version = "0.3.0",
+                    compatibility = """{"minConvxVersion":"2.0.0","maxConvxVersion":null}""",
+                    sha256 = digest,
+                ),
+                TestModulePackages.releaseJson(version = "0.1.5", sha256 = digest),
+            ),
+        )
+        val latest = updater.latestRelease(index.encodeToByteArray(), "spacemusic")
+        assertEquals("0.1.5", latest?.version)
+    }
+
+    @Test
+    fun `updater ignores other modules and malformed feeds`() {
+        val updater = ModuleUpdater("1.5.2")
+        val digest = "ab".repeat(32)
+        val index = TestModulePackages.releaseIndex(
+            moduleId = "other-module",
+            releases = listOf(TestModulePackages.releaseJson(version = "0.1.0", sha256 = digest)),
+        )
+        assertNull(updater.latestRelease(index.encodeToByteArray(), "spacemusic"))
+        assertRejected { updater.latestRelease("{not json".encodeToByteArray(), "spacemusic") }
+    }
+
+    @Test
+    fun `updater verifies the artifact against the declared sha256`() {
+        val updater = ModuleUpdater("1.5.2")
+        val artifact = TestModulePackages.packageBytes()
+        val digest = ModuleIntegrity.sha256Hex(artifact)
+        val release = TestModulePackages.releaseJson(version = "0.1.0", sha256 = digest)
+        val parsed = updater.latestRelease(
+            TestModulePackages.releaseIndex(releases = listOf(release)).encodeToByteArray(),
+            "spacemusic",
+        ) ?: error("release not found")
+
+        updater.verifyArtifact(parsed, artifact)
+        assertRejected {
+            updater.verifyArtifact(parsed.copy(sha256 = "cd".repeat(32)), artifact)
+        }
+        assertRejected {
+            updater.verifyArtifact(parsed.copy(sha256 = null), artifact)
+        }
+    }
+
+    private fun assertRejected(block: () -> Unit) {
+        try {
+            block()
+        } catch (_: ModuleValidationException) {
+            return
+        }
+        throw AssertionError("invalid module input was accepted")
+    }
+
+    private fun assertStateRejected(block: () -> Unit) {
+        try {
+            block()
+        } catch (_: IllegalStateException) {
+            return
+        }
+        throw AssertionError("invalid state transition was accepted")
+    }
+}

--- a/modulehost/src/test/kotlin/com/convx/modulehost/TestModulePackages.kt
+++ b/modulehost/src/test/kotlin/com/convx/modulehost/TestModulePackages.kt
@@ -1,0 +1,117 @@
+package com.convx.modulehost
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+internal object TestModulePackages {
+    const val SCHEMA_BASE = "https://raw.githubusercontent.com/N7T0-OF/Spacemusic/main/schemas/"
+
+    fun manifestJson(
+        id: String = "spacemusic",
+        version: String = "0.1.0",
+        type: String = "declarative",
+        permissions: String = "[\"settings\"]",
+        compatibility: String = """{"minConvxVersion":"1.5.2","maxConvxVersion":null}""",
+        schema: String = "${SCHEMA_BASE}manifest.schema.json",
+        extra: String = "",
+    ): String = """
+        {
+          "${'$'}schema":"$schema",
+          "schemaVersion":"0.1",
+          "id":"$id",
+          "name":"SpaceMusic",
+          "version":"$version",
+          "type":"$type",
+          "description":"A declarative music module for Convx.",
+          "author":"N7T0-OF",
+          "compatibility":$compatibility,
+          "permissions":$permissions,
+          "content":{"module":"module/module.json","icon":"assets/icon.svg"},
+          "updates":{"releaseIndex":"https://raw.githubusercontent.com/N7T0-OF/Spacemusic/main/releases/index.json"}$extra
+        }
+    """.trimIndent()
+
+    fun moduleJson(
+        moduleId: String = "spacemusic",
+        schema: String = "${SCHEMA_BASE}module.schema.json",
+        action: String = "check-updates",
+    ): String = """
+        {
+          "${'$'}schema":"$schema",
+          "schemaVersion":"0.1",
+          "moduleId":"$moduleId",
+          "contributions":{
+            "settings":{
+              "section":"SpaceMusic",
+              "icon":"assets/icon.svg",
+              "actions":[{"id":"$action","label":"Check for updates","action":"$action"}]
+            }
+          }
+        }
+    """.trimIndent()
+
+    fun packageEntries(
+        manifest: ByteArray = manifestJson().toByteArray(),
+        module: ByteArray = moduleJson().toByteArray(),
+    ): Map<String, ByteArray> = linkedMapOf(
+        "manifest.json" to manifest,
+        "module/module.json" to module,
+        "assets/icon.svg" to "<svg xmlns=\"http://www.w3.org/2000/svg\"/>".toByteArray(),
+    )
+
+    fun packageBytes(
+        manifest: String = manifestJson(),
+        module: String = moduleJson(),
+    ): ByteArray = zip(
+        packageEntries(manifest.toByteArray(), module.toByteArray()),
+    )
+
+    fun releaseJson(
+        moduleId: String = "spacemusic",
+        version: String = "0.1.0",
+        status: String = "published",
+        compatibility: String = """{"minConvxVersion":"1.5.2","maxConvxVersion":null}""",
+        artifact: String? = "https://example.com/releases/$version.smod",
+        sha256: String? = null,
+    ): String = """
+        {
+          "${'$'}schema":"${SCHEMA_BASE}release.schema.json",
+          "schemaVersion":"0.1",
+          "moduleId":"$moduleId",
+          "version":"$version",
+          "status":"$status",
+          "compatibility":$compatibility,
+          "artifact":${artifact?.let { "\"$it\"" } ?: "null"},
+          "sha256":${sha256?.let { "\"$it\"" } ?: "null"},
+          "notes":"test release"
+        }
+    """.trimIndent()
+
+    fun releaseIndex(
+        moduleId: String = "spacemusic",
+        releases: List<String>,
+    ): String = """
+        {
+          "${'$'}schema":"${SCHEMA_BASE}release-index.schema.json",
+          "schemaVersion":"0.1",
+          "moduleId":"$moduleId",
+          "releases":[${releases.joinToString(",")}]
+        }
+    """.trimIndent()
+
+    fun zip(entries: Map<String, ByteArray>): ByteArray =
+        zipEntries(entries.entries.map { it.key to it.value })
+
+    fun zipEntries(entries: Iterable<Pair<String, ByteArray>>): ByteArray {
+        val output = ByteArrayOutputStream()
+        ZipOutputStream(output).use { zip ->
+            entries.forEach { (name, payload) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(payload)
+                zip.closeEntry()
+            }
+        }
+        return output.toByteArray()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(":musixmatchlyrics")
 include(":jiosaavn")
 include(":spotify")
 include(":spine")
+include(":modulehost")
 
 
 // Use a local copy of NewPipe Extractor by uncommenting the lines below.


### PR DESCRIPTION
Superseded by #61. This fork branch was force-updated while its upstream base never moved, so #60 and #61 show the same full diff (v0.1 declarative host + v0.2 persistence/install). #61 is the canonical PR carrying both slices.